### PR TITLE
Added postgres .requests & .persistence.size; bumped version

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.2.0
+version: 1.2.1
 
 dependencies:
   - name: postgresql

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -63,6 +63,12 @@ postgresql:
       limits:
         cpu: "1000m"
         memory: "2000Mi"
+      requests:
+        memory: 256Mi
+        cpu: 250m
+    persistence:
+      enabled: true
+      size: 8Gi
 
 networking:
   type: ClusterIP


### PR DESCRIPTION
- added `postgres.requests.cpu` and `postgres.requests.memory` to match [upstream values](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml#L445-L447)
- added `postgres.persistence.enabled` and `postgres.persistence.size` to match [upstream values](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml#L669)
- mlflow chart version is now [`1.2.1`](https://github.com/InseeFrLab/helm-charts-automation/compare/master...odysseu:helm-charts-automation:master#diff-98f781e80dd894608d497332800f94e17b5ff71ca983fc70d958f7dc3c3be837R25)