### PR TITLE
added bumpVersion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "bumpVersion": "patch",
+  "helmv3": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
# WHAT?
- Added `bumpVersion` in the renovate.json.
# WHY ?
- When renovate did a MR, the chart version was not implemented in Chart.yaml. With this parameter it will be bumped
# OTHER
See reference [in the official documentation](https://docs.renovatebot.com/configuration-options/#bumpversion) and an example that works here: 

![image](https://github.com/InseeFrLab/helm-charts-interactive-services/assets/55583423/4c14c434-a861-4ef1-be7e-6ca7c29a3aa3)
