### PR TITLE
Mlflow `ingress:hostname` is changeable by default 

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.4.0
+version: 1.4.1
 
 dependencies:
   - name: postgresql

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -62,9 +62,6 @@
           "description": "directory of artifact root repository",
           "type": "string",
           "default": "/tmp/mlflow/artifacts/",
-          "x-form": {
-            "value": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
           }
@@ -83,9 +80,6 @@
         "accessKeyId": {
           "description": "AWS Access Key",
           "type": "string",
-          "x-form": {
-            "value": "{{s3.AWS_ACCESS_KEY_ID}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
           },
@@ -97,9 +91,6 @@
         "endpoint": {
           "description": "AWS S3 Endpoint",
           "type": "string",
-          "x-form": {
-            "value": "{{s3.AWS_S3_ENDPOINT}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
           },
@@ -111,9 +102,6 @@
         "defaultRegion": {
           "description": "AWS S3 default region",
           "type": "string",
-          "x-form": {
-            "value": "{{s3.AWS_DEFAULT_REGION}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
           },
@@ -125,9 +113,6 @@
         "secretAccessKey": {
           "description": "AWS S3 secret access key",
           "type": "string",
-          "x-form": {
-            "value": "{{s3.AWS_SECRET_ACCESS_KEY}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
           },
@@ -139,9 +124,6 @@
         "sessionToken": {
           "description": "AWS S3 session Token",
           "type": "string",
-          "x-form": {
-            "value": "{{s3.AWS_SESSION_TOKEN}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
           },
@@ -170,10 +152,6 @@
           "type": "string",
           "form": true,
           "title": "Hostname",
-          "x-form": {
-            "hidden": false,
-            "value": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
-          },
           "x-onyxia": {
             "hidden": false,
             "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
@@ -184,10 +162,6 @@
           "form": true,
           "title": "ingressClassName",
           "default": "",
-          "x-form": {
-            "hidden": true,
-            "value": "{{k8s.ingressClassName}}"
-          },
           "x-onyxia": {
             "hidden": true,
             "overwriteDefaultWith": "{{k8s.ingressClassName}}"
@@ -205,7 +179,7 @@
           "type": "boolean",
           "default": false,
           "x-onyxia": {
-            "hidden": true,
+            "hidden": false,
             "overwriteDefaultWith": "k8s.route"
           }
         },
@@ -214,7 +188,7 @@
           "form": true,
           "title": "Hostname",
           "x-onyxia": {
-            "hidden": true,
+            "hidden": false,
             "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
           }
         }
@@ -228,9 +202,6 @@
           "type": "string",
           "description": "Password",
           "default": "changeme",
-          "x-form": {
-            "value": "{{project.password}}"
-          },
           "x-onyxia": {
             "overwriteDefaultWith": "{{project.password}}"
           }
@@ -244,9 +215,6 @@
               "title": "Enable IP protection",
               "description": "Only the configured set of IPs will be able to reach the service",
               "default": true,
-              "x-form": {
-                "value": "{{region.defaultIpProtection}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "region.defaultIpProtection"
               }
@@ -256,9 +224,6 @@
               "description": "the white list of IP is whitespace",
               "title": "Whitelist of IP",
               "default": "0.0.0.0",
-              "x-form": {
-                "value": "{{user.ip}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "{{user.ip}}"
               },
@@ -278,9 +243,6 @@
               "title": "Enable network policy",
               "description": "Only pod from the same namespace will be allowed",
               "default": true,
-              "x-form": {
-                "value": "{{region.defaultNetworkPolicy}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "region.defaultNetworkPolicy"
               }
@@ -297,9 +259,6 @@
                   }
                 }
               ],
-              "x-form": {
-                "value": "{{region.from}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "region.from"
               }
@@ -413,9 +372,6 @@
               "type": "string",
               "title": "User",
               "default": "user",
-              "x-form": {
-                "value": "{{project.id}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.id}}"
               }
@@ -424,9 +380,6 @@
               "type": "string",
               "title": "User Password",
               "default": "changeme",
-              "x-form": {
-                "value": "{{project.password}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.password}}"
               }
@@ -435,9 +388,6 @@
               "type": "string",
               "title": "Admin Password",
               "default": "changeme",
-              "x-form": {
-                "value": "{{project.password}}"
-              },
               "x-onyxia": {
                 "overwriteDefaultWith": "{{project.password}}"
               }

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -6,161 +6,165 @@
       "description": "Service specific configuration",
       "type": "object",
       "properties": {
-          "image" : {
-              "description": "image docker",
-              "type": "object",  
+        "image": {
+          "description": "image docker",
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "type": "string",
+              "description": "option when pulling the docker image",
+              "default": "IfNotPresent",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
+            },
+            "version": {
+              "description": "supported versions",
+              "type": "string",
+              "listEnum": [
+                "inseefrlab/mlflow:v2.5.0",
+                "inseefrlab/mlflow:v2.2.2"
+              ],
+              "render": "list",
+              "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
+              "hidden": {
+                "value": true,
+                "path": "service/image/custom/enabled"
+              },
+              "default": "inseefrlab/mlflow:v2.2.2"
+            },
+            "custom": {
+              "description": "use a custom docker image",
+              "type": "object",
               "properties": {
-                "pullPolicy": {
-                  "type": "string",
-                  "description": "option when pulling the docker image",
-                  "default": "IfNotPresent",
-                  "enum": ["IfNotPresent","Always","Never"]
+                "enabled": {
+                  "title": "custom image",
+                  "type": "boolean",
+                  "description": "use a custom jupyter docker image",
+                  "default": false
                 },
                 "version": {
-                  "description": "supported versions",
+                  "description": "unsupported version",
                   "type": "string",
-                  "listEnum": [
-                      "inseefrlab/mlflow:v2.5.0",
-                      "inseefrlab/mlflow:v2.2.2"
-                  ],
-                  "render": "list",
-                  "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
+                  "default": "inseefrlab/mlflow:v2.2.2",
                   "hidden": {
-                      "value": true,
-                      "path": "service/image/custom/enabled"
-                  },
-                  "default": "inseefrlab/mlflow:v2.2.2"
-                },
-                "custom" : {
-                  "description": "use a custom docker image",
-                  "type": "object",  
-                  "properties": {
-                    "enabled": {
-                      "title": "custom image",
-                      "type": "boolean",
-                      "description": "use a custom jupyter docker image",
-                      "default": false
-                    },
-                    "version": {
-                      "description": "unsupported version",
-                      "type": "string",
-                      "default": "inseefrlab/mlflow:v2.2.2",
-                      "hidden": {
-                          "value": false,
-                          "path": "service/image/custom/enabled"
-                      }
-                    }
-                  }        
+                    "value": false,
+                    "path": "service/image/custom/enabled"
+                  }
                 }
-              }        
-          },
-          "directory": {
-            "description": "directory of artifact root repository",
-            "type": "string",
-            "default": "/tmp/mlflow/artifacts/",
-            "x-form": {
-              "value": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
-            },
-            "x-onyxia": {
-              "overwriteDefaultWith": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
+              }
             }
           }
+        },
+        "directory": {
+          "description": "directory of artifact root repository",
+          "type": "string",
+          "default": "/tmp/mlflow/artifacts/",
+          "x-form": {
+            "value": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "s3://{{s3.AWS_BUCKET_NAME}}/mlflow-artifacts"
+          }
+        }
       }
-  },
+    },
     "s3": {
       "description": "Configuration of temporary identity",
       "type": "object",
       "properties": {
-          "enabled": {
-              "type": "boolean",
-              "description": "Add S3 temporary identity inside your environment",
-              "default": true
+        "enabled": {
+          "type": "boolean",
+          "description": "Add S3 temporary identity inside your environment",
+          "default": true
+        },
+        "accessKeyId": {
+          "description": "AWS Access Key",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_ACCESS_KEY_ID}}"
           },
-          "accessKeyId": {
-              "description": "AWS Access Key",
-              "type": "string",
-              "x-form": {
-                  "value": "{{s3.AWS_ACCESS_KEY_ID}}"
-              },
-              "x-onyxia": {
-                  "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
-              },
-              "hidden": {
-                  "value": false,
-                  "path": "s3/enabled"
-              }
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_ACCESS_KEY_ID}}"
           },
-          "endpoint": {
-              "description": "AWS S3 Endpoint",
-              "type": "string",
-              "x-form": {
-                  "value": "{{s3.AWS_S3_ENDPOINT}}"
-              },
-              "x-onyxia": {
-                  "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
-              },
-              "hidden": {
-                  "value": false,
-                  "path": "s3/enabled"
-              }
-          },
-          "defaultRegion": {
-              "description": "AWS S3 default region",
-              "type": "string",
-              "x-form": {
-                  "value": "{{s3.AWS_DEFAULT_REGION}}"
-              },
-              "x-onyxia": {
-                  "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
-              },
-              "hidden": {
-                  "value": false,
-                  "path": "s3/enabled"
-              }
-          },
-          "secretAccessKey": {
-              "description": "AWS S3 secret access key",
-              "type": "string",
-              "x-form": {
-                  "value": "{{s3.AWS_SECRET_ACCESS_KEY}}"
-              },
-              "x-onyxia": {
-                  "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
-              },
-              "hidden": {
-                  "value": false,
-                  "path": "s3/enabled"
-              }
-          },
-          "sessionToken": {
-              "description": "AWS S3 session Token",
-              "type": "string",
-              "x-form": {
-                  "value": "{{s3.AWS_SESSION_TOKEN}}"
-              },
-              "x-onyxia": {
-                  "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
-              },
-              "hidden": {
-                  "value": false,
-                  "path": "s3/enabled"
-              }
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
           }
+        },
+        "endpoint": {
+          "description": "AWS S3 Endpoint",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_S3_ENDPOINT}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "defaultRegion": {
+          "description": "AWS S3 default region",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_DEFAULT_REGION}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "secretAccessKey": {
+          "description": "AWS S3 secret access key",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SECRET_ACCESS_KEY}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        },
+        "sessionToken": {
+          "description": "AWS S3 session Token",
+          "type": "string",
+          "x-form": {
+            "value": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{s3.AWS_SESSION_TOKEN}}"
+          },
+          "hidden": {
+            "value": false,
+            "path": "s3/enabled"
+          }
+        }
       }
-  },
+    },
     "ingress": {
       "type": "object",
       "form": true,
       "title": "Ingress Details",
       "properties": {
         "enabled": {
-            "description": "Enable Ingress",
-            "type": "boolean",
-            "default": true,
-            "x-onyxia": {
-                "hidden": true,
-                "overwriteDefaultWith": "k8s.ingress"
-            }
+          "description": "Enable Ingress",
+          "type": "boolean",
+          "default": true,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.ingress"
+          }
         },
         "hostname": {
           "type": "string",
@@ -171,136 +175,136 @@
             "value": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
           },
           "x-onyxia": {
-              "hidden": true,
-              "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
           }
         },
         "ingressClassName": {
-            "type": "string",
-            "form": true,
-            "title": "ingressClassName",
-            "default": "",
-            "x-form": {
-                "hidden": true,
-                "value": "{{k8s.ingressClassName}}"
-            },
-            "x-onyxia": {
-                "hidden": true,
-                "overwriteDefaultWith": "{{k8s.ingressClassName}}"
-            }
+          "type": "string",
+          "form": true,
+          "title": "ingressClassName",
+          "default": "",
+          "x-form": {
+            "hidden": true,
+            "value": "{{k8s.ingressClassName}}"
+          },
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{k8s.ingressClassName}}"
+          }
         }
       }
     },
     "route": {
-        "type": "object",
-        "form": true,
-        "title": "Route details",
-        "properties": {
-            "enabled": {
-                "description": "Enable route",
-                "type": "boolean",
-                "default": false,
-                "x-onyxia": {
-                    "hidden": true,
-                    "overwriteDefaultWith": "k8s.route"
-                }
-            },
-            "hostname": {
-                "type": "string",
-                "form": true,
-                "title": "Hostname",
-                "x-onyxia": {
-                    "hidden": true,
-                    "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
-                }
-            }
+      "type": "object",
+      "form": true,
+      "title": "Route details",
+      "properties": {
+        "enabled": {
+          "description": "Enable route",
+          "type": "boolean",
+          "default": false,
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "k8s.route"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "x-onyxia": {
+            "hidden": true,
+            "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
+          }
         }
+      }
     },
     "security": {
       "description": "security specific configuration",
       "type": "object",
       "properties": {
-          "password": {
-              "type": "string",
-              "description": "Password",
-              "default": "changeme",
+        "password": {
+          "type": "string",
+          "description": "Password",
+          "default": "changeme",
+          "x-form": {
+            "value": "{{project.password}}"
+          },
+          "x-onyxia": {
+            "overwriteDefaultWith": "{{project.password}}"
+          }
+        },
+        "allowlist": {
+          "type": "object",
+          "description": "IP protection",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable IP protection",
+              "description": "Only the configured set of IPs will be able to reach the service",
+              "default": true,
               "x-form": {
-                  "value": "{{project.password}}"
+                "value": "{{region.defaultIpProtection}}"
               },
               "x-onyxia": {
-                "overwriteDefaultWith": "{{project.password}}"
+                "overwriteDefaultWith": "region.defaultIpProtection"
               }
-          },
-          "allowlist": {
-            "type": "object",
-            "description": "IP protection",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "title": "Enable IP protection",
-                "description": "Only the configured set of IPs will be able to reach the service",
-                "default": true,
-                "x-form": {
-                  "value": "{{region.defaultIpProtection}}"
-                },
-                "x-onyxia": {
-                    "overwriteDefaultWith": "region.defaultIpProtection"
-                }
+            },
+            "ip": {
+              "type": "string",
+              "description": "the white list of IP is whitespace",
+              "title": "Whitelist of IP",
+              "default": "0.0.0.0",
+              "x-form": {
+                "value": "{{user.ip}}"
               },
-              "ip": {
-                "type": "string",
-                "description": "the white list of IP is whitespace",
-                "title": "Whitelist of IP",
-                "default": "0.0.0.0",
-                "x-form": {
-                  "value": "{{user.ip}}"
-                },
-                "x-onyxia": {
-                    "overwriteDefaultWith": "{{user.ip}}"
-                },
-                "hidden": {
-                    "value": false,
-                    "path": "security/allowlist/enabled"
-                } 
+              "x-onyxia": {
+                "overwriteDefaultWith": "{{user.ip}}"
+              },
+              "hidden": {
+                "value": false,
+                "path": "security/allowlist/enabled"
               }
             }
+          }
         },
         "networkPolicy": {
-            "type": "object",
-            "description": "Define access policy to the service",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "title": "Enable network policy",
-                "description": "Only pod from the same namespace will be allowed",
-                "default": true,
-                "x-form": {
-                  "value": "{{region.defaultNetworkPolicy}}"
-                },
-                "x-onyxia": {
-                    "overwriteDefaultWith": "region.defaultNetworkPolicy"
-                }
+          "type": "object",
+          "description": "Define access policy to the service",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable network policy",
+              "description": "Only pod from the same namespace will be allowed",
+              "default": true,
+              "x-form": {
+                "value": "{{region.defaultNetworkPolicy}}"
               },
-              "from": {
-                "type": "array",
-                "description": "Array of source allowed to have network access to your service",
-                "default" : [
-                  {
-                    "namespaceSelector": {
-                      "matchLabels": {
-                        "kubernetes.io/metadata.name": "ingress"
-                      }
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
+              }
+            },
+            "from": {
+              "type": "array",
+              "description": "Array of source allowed to have network access to your service",
+              "default": [
+                {
+                  "namespaceSelector": {
+                    "matchLabels": {
+                      "kubernetes.io/metadata.name": "ingress"
                     }
                   }
-                ], 
-                "x-form": {
-                    "value": "{{region.from}}"
-                },
-                "x-onyxia": {
-                    "overwriteDefaultWith": "region.from"
                 }
+              ],
+              "x-form": {
+                "value": "{{region.from}}"
+              },
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.from"
               }
             }
+          }
         }
       }
     },
@@ -308,74 +312,74 @@
       "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
       "type": "object",
       "properties": {
-          "requests": {
-              "description": "Guaranteed resources",
-              "type": "object",
-              "properties": {
-                "cpu": {
-                  "description": "The amount of cpu guaranteed",
-                  "title": "CPU",
-                  "type": "string",
-                  "default": "100m",
-                  "render": "slider",
-                  "sliderMin": 50,
-                  "sliderMax": 40000,
-                  "sliderStep": 50,
-                  "sliderUnit": "m",
-                  "sliderExtremity": "down",
-                  "sliderExtremitySemantic": "guaranteed",
-                  "sliderRangeId": "cpu"
-                },
-                "memory": {
-                  "description": "The amount of memory guaranteed",
-                  "title": "memory",
-                  "type": "string",
-                  "default": "2Gi",
-                  "render": "slider",
-                  "sliderMin": 1,
-                  "sliderMax": 200,
-                  "sliderStep": 1,
-                  "sliderUnit": "Gi",
-                  "sliderExtremity": "down",
-                  "sliderExtremitySemantic": "guaranteed",
-                  "sliderRangeId": "memory"
-                }
-              }
-          },
-          "limits": {
-              "description": "max resources",
-              "type": "object",
-              "properties": {
-                  "cpu": {
-                      "description": "The maximum amount of cpu",
-                      "title": "CPU",
-                      "type": "string",
-                      "default": "30000m",
-                      "render": "slider",
-                      "sliderMin": 50,
-                      "sliderMax": 40000,
-                      "sliderStep": 50,
-                      "sliderUnit": "m",
-                      "sliderExtremity": "up",
-                      "sliderExtremitySemantic": "Maximum",
-                      "sliderRangeId": "cpu"
-                    },
-                    "memory": {
-                      "description": "The maximum amount of memory",
-                      "title": "Memory", 
-                      "type": "string",
-                      "default": "50Gi",
-                      "render": "slider",
-                      "sliderMin": 1,
-                      "sliderMax": 200,
-                      "sliderStep": 1,
-                      "sliderUnit": "Gi",
-                      "sliderExtremity": "up",
-                      "sliderExtremitySemantic": "Maximum",
-                      "sliderRangeId": "memory"
-                    }
-              }
+        "requests": {
+          "description": "Guaranteed resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "The amount of cpu guaranteed",
+              "title": "CPU",
+              "type": "string",
+              "default": "100m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "The amount of memory guaranteed",
+              "title": "memory",
+              "type": "string",
+              "default": "2Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "down",
+              "sliderExtremitySemantic": "guaranteed",
+              "sliderRangeId": "memory"
+            }
           }
+        },
+        "limits": {
+          "description": "max resources",
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "description": "The maximum amount of cpu",
+              "title": "CPU",
+              "type": "string",
+              "default": "30000m",
+              "render": "slider",
+              "sliderMin": 50,
+              "sliderMax": 40000,
+              "sliderStep": 50,
+              "sliderUnit": "m",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "cpu"
+            },
+            "memory": {
+              "description": "The maximum amount of memory",
+              "title": "Memory",
+              "type": "string",
+              "default": "50Gi",
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 200,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "sliderExtremity": "up",
+              "sliderExtremitySemantic": "Maximum",
+              "sliderRangeId": "memory"
+            }
+          }
+        }
       }
     },
     "postgresql": {
@@ -390,7 +394,12 @@
             "tag": {
               "description": "postgresql major version",
               "type": "string",
-              "enum": ["12", "13", "14", "15"],
+              "enum": [
+                "12",
+                "13",
+                "14",
+                "15"
+              ],
               "default": "15"
             }
           }

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -171,11 +171,11 @@
           "form": true,
           "title": "Hostname",
           "x-form": {
-            "hidden": true,
+            "hidden": false,
             "value": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
           },
           "x-onyxia": {
-            "hidden": true,
+            "hidden": false,
             "overwriteDefaultWith": "{{project.id}}-{{k8s.randomSubdomain}}.{{k8s.domain}}"
           }
         },


### PR DESCRIPTION
The [only real change](https://github.com/InseeFrLab/helm-charts-automation/pull/33/commits/9f3a3949f00ae433d4e9328766c4a05a24b4c181) is this : 

```yaml

    "ingress": {
      "properties": {
        "hostname": {
          "x-form": {
            "hidden": true,
          "x-onyxia": {
            "hidden": true,
```
are now

```yaml

    "ingress": {
      "properties": {
        "hostname": {
          "x-form": {
            "hidden": false,
          "x-onyxia": {
            "hidden": false,
```
so a user can actually **choose the name of its mlflow's hostname**