### PR TITLE
add authentication but disabled by default

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.4.1
+version: 1.5.0
 
 dependencies:
   - name: postgresql

--- a/charts/mlflow/templates/NOTES.txt
+++ b/charts/mlflow/templates/NOTES.txt
@@ -5,6 +5,13 @@
 - You can connect to the mlflow UI with your browser on this [link](https://{{ .Values.route.hostname }})
 {{- end }}
 
+{{- if  .Values.security.auth.basic.enabled }}
+- You can connect with  username {{ .Values.security.auth.basic.username }} and password {{ .Values.security.auth.basic.password }}
+
+For your client use MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD
+
+{{- end }}
+
 *NOTES about deletion :*
 
 - **You can safely delete this chart and recreate one later**

--- a/charts/mlflow/templates/configmap-mlflow-auth.yaml
+++ b/charts/mlflow/templates/configmap-mlflow-auth.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.security.auth.basic.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap-mlflow-auth
+data:
+  basic_auth.ini: |
+    [mlflow]
+    default_permission = READ
+    database_uri = sqlite:///basic_auth.db
+    admin_username = {{ .Values.security.auth.basic.username }}
+    admin_password = {{ .Values.security.auth.basic.password }}
+    authorization_function = mlflow.server.auth:authenticate_request_basic_auth
+{{- end -}}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
       labels:
         {{- include "library-chart.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.security.auth.basic.enabled }}
+      volumes:
+      - name: configmap-auth-ini-volume
+        configMap:
+          name: {{ .Release.Name }}-configmap-mlflow-auth
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -41,7 +47,10 @@ spec:
             - --artifacts-destination={{ .Values.service.directory }}
             {{- else -}}
             - --default-artifact-root={{ .Values.service.directory }}
-            {{- end -}}
+            {{- end }}
+            {{ if .Values.security.auth.basic.enabled -}}
+            - --app-name=basic-auth
+            {{- end }}
             {{  range .Values.service.customArgs }}
             - {{ . }}
             {{- end }}
@@ -51,9 +60,19 @@ spec:
             - configMapRef:
                 name: {{ include "library-chart.configMapNameS3" . }}
             {{- end }}
+          {{- if .Values.security.auth.basic.enabled }}
+          volumeMounts:
+          - name: configmap-auth-ini-volume
+            mountPath: /home/oyxia/work/basic_auth.ini
+            subPath: basic_auth.ini 
+          {{- end }}
           env:
             - name: MLFLOW_S3_ENDPOINT_URL
               value: "https://{{ .Values.s3.endpoint }}"
+            {{- if .Values.security.auth.basic.enabled }}
+            - name: MLFLOW_AUTH_CONFIG_PATH
+              value: /home/oyxia/work/basic_auth.ini
+            {{- end }}
             - name: GUNICORN_CMD_ARGS
               value: "--timeout {{ .Values.service.gunicornTimeout }}"
           ports:

--- a/charts/mlflow/templates/discovery-secret.yaml
+++ b/charts/mlflow/templates/discovery-secret.yaml
@@ -14,4 +14,8 @@ data:
   {{ else }}
   uri: {{ printf "http://%s" $fullname | b64enc | quote }}
   {{ end }}
+  {{ if .Values.security.auth.basic.enabled -}}
+  MLFLOW_TRACKING_USERNAME: {{ .Values.security.auth.basic.username | b64enc | quote }}
+  MLFLOW_TRACKING_PASSWORD: {{ .Values.security.auth.basic.username | b64enc | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 service:
   image:
-    version: ""
+    version: "inseefrlab/mlflow:v2.5.0"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
@@ -37,6 +37,13 @@ liveness:
   enabled : "true"
 
 security:
+  # should be configured https://mlflow.org/docs/latest/tracking.html#scenario-5-mlflow-tracking-server-enabled-with-proxied-artifact-storage-access
+  # with proxyArtifact.enabled:true
+  auth:
+    basic:
+      enabled: false
+      username: "admin"
+      password: "changeme"
   networkPolicy: 
     enabled: false
     from: 


### PR DESCRIPTION
This PR add to the chart mlflow authentication basic feature only in the helm chart, for that from my understandring:

- an environement variable is set to specify a .ini file where basic auth mlflow configuraion is described.
- from now on mlflow auth is experimental feature and the database users/permissions is a sqlite one that is launch in home/onyxia/work when configuring only one user there is no need to persist this setup that is independant from s3 and postgres storage.

- i have not test but i think the auth is only effective when  we are in this setup https://mlflow.org/docs/latest/tracking.html#scenario-5-mlflow-tracking-server-enabled-with-proxied-artifact-storage-access

This PR can be merged as auth behaviour si controlled by the values security.auth.basic.enabled that is currently false.

After this PR one could probably changes values.schema.json to let onyxia override security.auth.basic.enabled : true and username (onyxia?) and password (projet password?).

Be careful to tutorials and documentation because having an mlflow with basic auth need to update the client part with  https://mlflow.org/docs/latest/auth/index.html#authenticating-to-mlflow probably 
export MLFLOW_TRACKING_USERNAME=username
export MLFLOW_TRACKING_PASSWORD=password



