### PR TITLE
Fix argocd

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.8
+version: 0.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -50,6 +50,7 @@ argo-cd:
   applicationSet:
     enabled: false
   createAggregateRoles: false
+  createClusterRoles: false
   fullnameOverride: "argocd"
   controller:
     name: application-controller


### PR DESCRIPTION
#65 did not account for some breaking changes introduced by argocd v6.  
This PR fixes one of them, the only one strictly blocking. There may be more to changes to address but at least the chart will be functional once again and won't create cluster-wide (ClusterRole) resources