### PR TITLE
argo-cd deprecated elements

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.9
+version: 0.5.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1,6 +1,6 @@
 # argo-cd
 
-![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.10](https://img.shields.io/badge/Version-0.5.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
 
@@ -25,11 +25,6 @@ Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
 | apiserver | string | `"https://kubernetes.default.svc"` |  |
 | argo-cd.applicationSet.enabled | bool | `false` |  |
 | argo-cd.configs.secret.createSecret | bool | `false` |  |
-| argo-cd.controller.args.appResyncPeriod | string | `"180"` |  |
-| argo-cd.controller.args.operationProcessors | string | `"10"` |  |
-| argo-cd.controller.args.repoServerTimeoutSeconds | string | `"60"` |  |
-| argo-cd.controller.args.selfHealTimeout | string | `"5"` |  |
-| argo-cd.controller.args.statusProcessors | string | `"20"` |  |
 | argo-cd.controller.clusterAdminAccess.enabled | bool | `false` |  |
 | argo-cd.controller.clusterRoleRules.enabled | bool | `false` |  |
 | argo-cd.controller.clusterRoleRules.rules | list | `[]` |  |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -60,12 +60,6 @@ argo-cd:
       imagePullPolicy: # IfNotPresent
     replicas: 1
     enableStatefulSet: true
-    args:
-      statusProcessors: "20"
-      operationProcessors: "10"
-      appResyncPeriod: "180"
-      selfHealTimeout: "5"
-      repoServerTimeoutSeconds: "60"
     extraArgs:
       - --namespace
       - $(KUBERNETES_NAMESPACE)


### PR DESCRIPTION
from [the differences in the values.yml of the upstream chart](https://github.com/argoproj/argo-helm/compare/argo-cd-5.51.4...argo-cd-6.2.3#diff-9eb59d56febda5e405748483497dfdc0c2dfbe9b4f386a12f0180c98d99051e0), I figured
- `argo-cd.controller.args` are [deprecated](https://github.com/argoproj/argo-helm/compare/argo-cd-5.51.4...argo-cd-6.2.3?diff=unified&w=#diff-9eb59d56febda5e405748483497dfdc0c2dfbe9b4f386a12f0180c98d99051e0L622-L637)