### PR TITLE
Fix argo-cd and argo-workflows IngressClassName and cpu-memory quotas

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-cd/templates/ingress.yaml
+++ b/charts/argo-cd/templates/ingress.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations:
     {{- include "library-chart.ingress.annotations" . | nindent 4 }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:

--- a/charts/argo-cd/values.schema.json
+++ b/charts/argo-cd/values.schema.json
@@ -142,7 +142,7 @@
         },
         "server": {
           "type": "object",
-          "title": "controller",
+          "title": "Server",
           "properties": {
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",

--- a/charts/argo-cd/values.schema.json
+++ b/charts/argo-cd/values.schema.json
@@ -144,6 +144,13 @@
           "type": "object",
           "title": "controller",
           "properties": {
+            "resources": {
+              "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
+              "type": "object",
+              "x-onyxia": {
+                "overwriteSchemaWith": "ide/resources.json"
+              }
+            },
             "tolerations": {
               "type": "array",
               "description": "Array of tolerations",
@@ -170,6 +177,13 @@
           "type": "object",
           "title": "controller",
           "properties": {
+            "resources": {
+              "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
+              "type": "object",
+              "x-onyxia": {
+                "overwriteSchemaWith": "ide/resources.json"
+              }
+            },
             "tolerations": {
               "type": "array",
               "description": "Array of tolerations",

--- a/charts/argo-cd/values.schema.json
+++ b/charts/argo-cd/values.schema.json
@@ -147,9 +147,76 @@
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
               "type": "object",
-              "x-onyxia": {
-                "overwriteSchemaWith": "ide/resources.json"
-              }
+              "properties": {
+                "requests": {
+                    "description": "Guaranteed resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The amount of cpu guaranteed",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "100m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The amount of memory guaranteed",
+                            "title": "memory",
+                            "type": "string",
+                            "default": "200Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                },
+                "limits": {
+                    "description": "max resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The maximum amount of cpu",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "2000m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The maximum amount of memory",
+                            "title": "Memory",
+                            "type": "string",
+                            "default": "2000Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                }
+            }
             },
             "tolerations": {
               "type": "array",
@@ -180,9 +247,76 @@
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
               "type": "object",
-              "x-onyxia": {
-                "overwriteSchemaWith": "ide/resources.json"
-              }
+              "properties": {
+                "requests": {
+                    "description": "Guaranteed resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The amount of cpu guaranteed",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "100m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The amount of memory guaranteed",
+                            "title": "memory",
+                            "type": "string",
+                            "default": "200Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                },
+                "limits": {
+                    "description": "max resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The maximum amount of cpu",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "2000m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The maximum amount of memory",
+                            "title": "Memory",
+                            "type": "string",
+                            "default": "2000Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                }
+            }
             },
             "tolerations": {
               "type": "array",

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -59,7 +59,13 @@ argo-cd:
       tag: # defaults to global.image.tag
       imagePullPolicy: # IfNotPresent
     replicas: 1
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 2000m
+        memory: 2000Mi
     enableStatefulSet: true
     args:
       statusProcessors: "20"
@@ -82,7 +88,6 @@ argo-cd:
     service:
       port: 443
       portName: https-controller
-    resources: {}
     serviceAccount:
       create: true
       name: argocd-application-controller
@@ -102,7 +107,13 @@ argo-cd:
   server:
     name: server
     replicas: 1
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 2000m
+        memory: 2000Mi
     extraArgs:
       - --namespace
       - $(KUBERNETES_NAMESPACE)

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -59,6 +59,7 @@ argo-cd:
       tag: # defaults to global.image.tag
       imagePullPolicy: # IfNotPresent
     replicas: 1
+    resources: {}
     enableStatefulSet: true
     args:
       statusProcessors: "20"
@@ -101,6 +102,7 @@ argo-cd:
   server:
     name: server
     replicas: 1
+    resources: {}
     extraArgs:
       - --namespace
       - $(KUBERNETES_NAMESPACE)

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-workflows/templates/ingress.yaml
+++ b/charts/argo-workflows/templates/ingress.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations:
     {{- include "library-chart.ingress.annotations" . | nindent 4 }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- if .Values.ingress.ingressClassName }}
+   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:

--- a/charts/argo-workflows/templates/networkpolicy-ingress.yaml
+++ b/charts/argo-workflows/templates/networkpolicy-ingress.yaml
@@ -9,8 +9,10 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
   ingress:
-  - from:
-    {{- toYaml .Values.security.networkPolicy.from | nindent 4 }}
+  {{- with .Values.security.networkPolicy.from }}
+   - from:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   policyTypes:
   - Ingress
 {{- end }}

--- a/charts/argo-workflows/values.schema.json
+++ b/charts/argo-workflows/values.schema.json
@@ -113,7 +113,7 @@
       "properties": {
         "server": {
           "type": "object",
-          "title": "controller",
+          "title": "Server",
           "properties": {
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",

--- a/charts/argo-workflows/values.schema.json
+++ b/charts/argo-workflows/values.schema.json
@@ -118,9 +118,76 @@
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
               "type": "object",
-              "x-onyxia": {
-                "overwriteSchemaWith": "ide/resources.json"
-              }
+              "properties": {
+                "requests": {
+                    "description": "Guaranteed resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The amount of cpu guaranteed",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "100m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The amount of memory guaranteed",
+                            "title": "memory",
+                            "type": "string",
+                            "default": "200Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                },
+                "limits": {
+                    "description": "max resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The maximum amount of cpu",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "2000m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The maximum amount of memory",
+                            "title": "Memory",
+                            "type": "string",
+                            "default": "2000Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                }
+            }
             },
             "tolerations": {
               "type": "array",
@@ -151,9 +218,76 @@
             "resources": {
               "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
               "type": "object",
-              "x-onyxia": {
-                "overwriteSchemaWith": "ide/resources.json"
-              }
+              "properties": {
+                "requests": {
+                    "description": "Guaranteed resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The amount of cpu guaranteed",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "100m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The amount of memory guaranteed",
+                            "title": "memory",
+                            "type": "string",
+                            "default": "200Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "down",
+                            "sliderExtremitySemantic": "guaranteed",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                },
+                "limits": {
+                    "description": "max resources",
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "description": "The maximum amount of cpu",
+                            "title": "CPU",
+                            "type": "string",
+                            "default": "2000m",
+                            "render": "slider",
+                            "sliderMin": 50,
+                            "sliderMax": 16000,
+                            "sliderStep": 50,
+                            "sliderUnit": "m",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "cpu"
+                        },
+                        "memory": {
+                            "description": "The maximum amount of memory",
+                            "title": "Memory",
+                            "type": "string",
+                            "default": "2000Mi",
+                            "render": "slider",
+                            "sliderMin": 100,
+                            "sliderMax": 8000,
+                            "sliderStep": 100,
+                            "sliderUnit": "Mi",
+                            "sliderExtremity": "up",
+                            "sliderExtremitySemantic": "Maximum",
+                            "sliderRangeId": "memory"
+                        }
+                    }
+                }
+            }
             },
             "tolerations": {
               "type": "array",

--- a/charts/argo-workflows/values.schema.json
+++ b/charts/argo-workflows/values.schema.json
@@ -69,27 +69,27 @@
           "type": "object",
           "description": "Define access policy to the service",
           "x-onyxia": {
-              "overwriteSchemaWith": "network-policy.json"
+            "overwriteSchemaWith": "network-policy.json"
           },
           "properties": {
-              "enabled": {
-                  "type": "boolean",
-                  "title": "Enable network policy",
-                  "description": "Only pod from the same namespace will be allowed",
-                  "default": false,
-                  "x-onyxia": {
-                      "overwriteDefaultWith": "region.defaultNetworkPolicy"
-                  }
-              },
-              "from": {
-                  "type": "array",
-                  "description": "Array of source allowed to have network access to your service",
-                  "default": [],
-                  "x-onyxia": {
-                      "hidden": true,
-                      "overwriteDefaultWith": "region.from"
-                  }
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable network policy",
+              "description": "Only pod from the same namespace will be allowed",
+              "default": false,
+              "x-onyxia": {
+                "overwriteDefaultWith": "region.defaultNetworkPolicy"
               }
+            },
+            "from": {
+              "type": "array",
+              "description": "Array of source allowed to have network access to your service",
+              "default": [],
+              "x-onyxia": {
+                "hidden": true,
+                "overwriteDefaultWith": "region.from"
+              }
+            }
           }
         }
       }
@@ -115,6 +115,13 @@
           "type": "object",
           "title": "controller",
           "properties": {
+            "resources": {
+              "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
+              "type": "object",
+              "x-onyxia": {
+                "overwriteSchemaWith": "ide/resources.json"
+              }
+            },
             "tolerations": {
               "type": "array",
               "description": "Array of tolerations",
@@ -141,6 +148,13 @@
           "type": "object",
           "title": "controller",
           "properties": {
+            "resources": {
+              "description": "Your service will have at least the requested resources and never more than its limits. No limit for a resource and you can consume everything left on the host machine.",
+              "type": "object",
+              "x-onyxia": {
+                "overwriteSchemaWith": "ide/resources.json"
+              }
+            },
             "tolerations": {
               "type": "array",
               "description": "Array of tolerations",

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -50,6 +50,7 @@ argo-workflows:
       annotations: {}
       name: "argo-workflows" # Service account which is used to run workflows
   controller:
+    resources: {}
     workflowNamespaces: []
     replicas: 1
     #containerRuntimeExecutor: k8sapi
@@ -57,6 +58,7 @@ argo-workflows:
       enabled: false
 
   server:
+    resources: {}
     enabled: true
     clusterWorkflowTemplates:
       enabled: false

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -50,7 +50,13 @@ argo-workflows:
       annotations: {}
       name: "argo-workflows" # Service account which is used to run workflows
   controller:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 2000m
+        memory: 2000Mi   
     workflowNamespaces: []
     replicas: 1
     #containerRuntimeExecutor: k8sapi
@@ -58,7 +64,13 @@ argo-workflows:
       enabled: false
 
   server:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 2000m
+        memory: 2000Mi 
     enabled: true
     clusterWorkflowTemplates:
       enabled: false


### PR DESCRIPTION
Hi,

# The issue
We encounter some troubles running argo-cd and argo-workflows on our onyxia instance for 2 reasons:
- We don't have a custom StorageClass on our kubernetes cluster
- Our onyxia instance is configured with cpu and memory quotas

# The Fix
- Only set the StorageClassName attribute when StorageClass is not falsy
- Configure the `"overwriteSchemaWith": "ide/resources.json"` in the `values.schema.json` files for the different deployments

# Tests
- `helm lint .` is working for both charts